### PR TITLE
Update documentation and removing 32-bit support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,15 +13,12 @@ builds:
     - darwin
   goarch:
     - amd64
-    - '386'
     - arm64
   ignore:
     - goos: windows
       goarch: 'arm64'
     - goos: linux
       goarch: 'arm64'
-    - goos: darwin
-      goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The `digicert_certificate` resource allows you to issue and manage certificates.
 resource "digicert_certificate" "example" {
   profile_id  = "8e201a92-4b16-412d-aa5c-bbeba3dacdef"
   common_name = "example.com"
-  dns_names   = ["www.example.com", "api.example.com"]
+  dns_names   = "www.example.com,api.example.com"
   csr         = "-----BEGIN CERTIFICATE REQUEST-----\nMIICjzCCAX/ZvGPbg=\n-----END CERTIFICATE REQUEST-----\n"
 }
 ```
@@ -96,8 +96,8 @@ resource "digicert_certificate" "example" {
 resource "digicert_certificate" "cert" {
   profile_id  = "8e201a92-4b16-412d-aa5c-bbeba3dacdef"
   common_name = "example.com"
-  dns_names   = ["www.example.com", "api.example.com"]
-  tags        = ["production", "web-servers"]
+  dns_names   = "www.example.com,api.example.com"
+  tags        = "production,web-servers"
 }
 ```
 
@@ -107,9 +107,9 @@ resource "digicert_certificate" "cert" {
 |--------------|---------------------------------------------------------------|----------------|----------|
 | profile_id   | ID of an existing DigiCert​​®​​ Trust Lifecycle Manager profile to use for certificate | String         | Yes      |
 | common_name  | Common name of the certificate                                | String         | Yes      |
-| dns_names    | SANs of the certificate, if any                               | List of Strings| No       |
+| dns_names    | SANs of the certificate, if any                               | Comma separated list of Strings| No       |
 | csr          | Certificate Signing Request (CSR) in PEM format               | String         | No       |
-| tags         | Tags to attach to the certificate                             | List of Strings| No       |
+| tags         | Tags to attach to the certificate                             | Comma separated list of Strings| No       |
 
 After enrollment, the `digicert_certificate` resource will expose:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ The `digicert_certificate` resource allows you to issue and manage certificates.
 resource "digicert_certificate" "example" {
   profile_id  = "8e201a92-4b16-412d-aa5c-bbeba3dacdef"
   common_name = "example.com"
-  dns_names   = ["www.example.com", "api.example.com"]
+  dns_names   = "www.example.com,api.example.com"
   csr         = "-----BEGIN CERTIFICATE REQUEST-----\nMIICjzCCAX/ZvGPbg=\n-----END CERTIFICATE REQUEST-----\n"
 }
 ```
@@ -39,8 +39,8 @@ resource "digicert_certificate" "example" {
 resource "digicert_certificate" "cert" {
   profile_id  = "8e201a92-4b16-412d-aa5c-bbeba3dacdef"
   common_name = "example.com"
-  dns_names   = ["www.example.com", "api.example.com"]
-  tags        = ["production", "web-servers"]
+  dns_names   = "www.example.com,api.example.com"
+  tags        = "production,web-servers"
 }
 ```
 
@@ -50,9 +50,9 @@ resource "digicert_certificate" "cert" {
 |--------------|---------------------------------------------------------------|----------------|----------|
 | profile_id   | ID of an existing DigiCert​​®​​ Trust Lifecycle Manager profile to use for certificate | String         | Yes      |
 | common_name  | Common name of the certificate                                | String         | Yes      |
-| dns_names    | SANs of the certificate, if any                               | List of Strings| No       |
+| dns_names    | SANs of the certificate, if any                               | Comma separated list of Strings| No       |
 | csr          | Certificate Signing Request (CSR) in PEM format               | String         | No       |
-| tags         | Tags to attach to the certificate                             | List of Strings| No       |
+| tags         | Tags to attach to the certificate                             | Comma separated list of Strings| No       |
 
 After enrollment, the `digicert_certificate` resource will expose:
 

--- a/internal/digicert/client.go
+++ b/internal/digicert/client.go
@@ -204,6 +204,7 @@ func buildIssuanceRequest(issuanceData *issuanceData) *model.CertificateRequest 
 		Attributes:     attributes,
 		DeliveryFormat: issuanceData.profile.CertificateDeliveryFormat,
 		IncludeCaChain: true,
+		Tags:           issuanceData.tags,
 	}
 }
 


### PR DESCRIPTION
This pull request includes the following changes:

1. Removed support for 32-bit (386) binaries, dropped support for both Windows and Linux 32-bit architectures.
2. Documentation update for the `digicert_certificate` resource to reflect the correct way of passing multiple `dns_names` and `tags`.
3. Bug fix: 
- Fixed an issue where the certificate tags in the provider were being passed correctly but were not appearing in the      Digicert ONE TLM UI.